### PR TITLE
DEPT 338 Add banner image to Twig templates for full node view

### DIFF
--- a/templates/content/node--consultation--full.html.twig
+++ b/templates/content/node--consultation--full.html.twig
@@ -71,6 +71,9 @@
  */
 #}
 <article{{ attributes.setAttribute('id', 'main-article').removeAttribute('role') }}>
+  {% if banner_image %}
+    {{ banner_image }}
+  {% endif %}
   <div class="narrow-title">
   {% if show_title %}
   {{ drupal_block('page_title_block', wrapper=false) }}

--- a/templates/content/node--contact--full.html.twig
+++ b/templates/content/node--contact--full.html.twig
@@ -71,6 +71,9 @@
  */
 #}
 <article{{ attributes.setAttribute('id', 'main-article').removeAttribute('role') }}>
+  {% if banner_image %}
+    {{ banner_image }}
+  {% endif %}
   {% if show_title %}
   {{ drupal_block('page_title_block', wrapper=false) }}
   {% endif %}

--- a/templates/content/node--full.html.twig
+++ b/templates/content/node--full.html.twig
@@ -71,6 +71,9 @@
  */
 #}
 <article{{ attributes.setAttribute('id', 'main-article').removeAttribute('role') }}>
+  {% if banner_image %}
+    {{ banner_image }}
+  {% endif %}
   {% if show_title %}
   {{ drupal_block('page_title_block', wrapper=false) }}
   {% endif %}
@@ -80,7 +83,7 @@
   {% if content_attributes is not empty %}
   <div{{ content_attributes }}>
   {% endif %}
-  {{- content -}}
+  {{ content }}
   {% if content_attributes is not empty %}
   </div>
   {% endif %}

--- a/templates/content/node--heritage_site--full.html.twig
+++ b/templates/content/node--heritage_site--full.html.twig
@@ -70,6 +70,9 @@
  *   in different view modes.
  */
 #}
+{% if banner_image %}
+  {{ banner_image }}
+{% endif %}
 <article{{ attributes.setAttribute('id', 'main-article').removeAttribute('role') }}>
   {% if show_topics and topics_subtopics_list is not empty %}
     {{ topics_subtopics_list }}

--- a/templates/content/node--news--full.html.twig
+++ b/templates/content/node--news--full.html.twig
@@ -71,6 +71,9 @@
  */
 #}
 <article{{ attributes.setAttribute('id', 'main-article').removeAttribute('role') }}>
+  {% if banner_image %}
+    {{ banner_image }}
+  {% endif %}
   {% if show_title %}
   {{ drupal_block('page_title_block', wrapper=false) }}
   {% endif %}

--- a/templates/content/node--publication--full.html.twig
+++ b/templates/content/node--publication--full.html.twig
@@ -71,6 +71,9 @@
  */
 #}
 <article{{ attributes.setAttribute('id', 'main-article').removeAttribute('role') }}>
+  {% if banner_image %}
+    {{ banner_image }}
+  {% endif %}
   <div class="narrow-title">
   {% if show_title %}
     {{ drupal_block('page_title_block', wrapper=false) }}

--- a/templates/content/node--subtopic--full.html.twig
+++ b/templates/content/node--subtopic--full.html.twig
@@ -71,6 +71,9 @@
  */
 #}
 <article{{ attributes.setAttribute('id', 'main-article').removeAttribute('role') }}>
+  {% if banner_image %}
+    {{ banner_image }}
+  {% endif %}
   {% if show_title %}
     {{ drupal_block('page_title_block', wrapper=false) }}
   {% endif %}

--- a/templates/content/node--topic--full.html.twig
+++ b/templates/content/node--topic--full.html.twig
@@ -70,6 +70,9 @@
  *   in different view modes.
  */
 #}
+{% if banner_image %}
+  {{ banner_image }}
+{% endif %}
 <article{{ attributes.setAttribute('id', 'main-article').removeAttribute('role') }}>
   <div class="narrow-title">
     {% if show_title %}


### PR DESCRIPTION
Heritage site template differs a little as it may not have been fully styled as per others, but the Twig block can be adjusted as required.

What renders in that slot would be a image media entity in thin_banner view mode, which ought to render a responsive image with the corresponding image style.