### PR TITLE
DEPT-304 facets and search tweaks

### DIFF
--- a/inc/preprocess.inc
+++ b/inc/preprocess.inc
@@ -367,12 +367,13 @@ function nicsdru_dept_theme_preprocess_node(array &$variables) {
 function nicsdru_dept_theme_preprocess_block(array &$variables) {
   // Set department logo for system branding block.
   if ($variables['plugin_id'] === 'system_branding_block') {
-    /** @var \Drupal\dept_core\Entity\Department $dept */
     $dept = \Drupal::service('department.manager')->getCurrentDepartment();
 
     if (is_object($dept) && method_exists($dept, 'id')) {
       $variables["department_logo"] = 'logo-' . $dept->id() . '.svg';
-      $variables['site_name'] = $dept->name();
+      if (method_exists($dept, 'name')) {
+        $variables['site_name'] = $dept->name();
+      }
     }
     else {
       $variables["department_logo"] = 'logo-admin.svg';

--- a/templates/misc/facets-item-list.html.twig
+++ b/templates/misc/facets-item-list.html.twig
@@ -1,0 +1,66 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a facets item list.
+ *
+ * Available variables:
+ * - items: A list of items. Each item contains:
+ *   - attributes: HTML attributes to be applied to each list item.
+ *   - value: The content of the list element.
+ * - title: The title of the list.
+ * - list_type: The tag for list element ("ul" or "ol").
+ * - wrapper_attributes: HTML attributes to be applied to the list wrapper.
+ * - attributes: HTML attributes to be applied to the list.
+ * - empty: A message to display when there are no items. Allowed value is a
+ *   string or render array.
+ * - context: A list of contextual data associated with the list. May contain:
+ *   - list_style: The ID of the widget plugin this facet uses.
+ * - facet: The facet for this result item.
+ *   - id: the machine name for the facet.
+ *   - label: The facet label.
+ *
+ * @see facets_preprocess_facets_item_list()
+ *
+ * @ingroup themeable
+ */
+#}
+{% set title = '' %}
+
+{% if cache_hash %}
+  <!-- facets cacheable metadata
+    hash: {{ cache_hash }}
+  {% if cache_contexts %}
+    contexts: {{ cache_contexts }}
+  {%- endif %}
+  {% if cache_tags %}
+    tags: {{ cache_tags }}
+  {%- endif %}
+  {% if cache_max_age %}
+    max age: {{ cache_max_age }}
+  {%- endif %}
+  -->
+{%- endif %}
+<div class="facets-widget- {{- facet.widget.type -}} ">
+  {% if facet.widget.type %}
+    {%- set attributes = attributes.addClass('item-list__' ~ facet.widget.type) %}
+  {% endif %}
+  {% if items or empty %}
+    {%- if title is not empty -%}
+      <h3>{{ title }}</h3>
+    {%- endif -%}
+
+    {%- if items -%}
+      <{{ list_type }}{{ attributes }}>
+        {%- for item in items -%}
+          <li{{ item.attributes }}>{{ item.value }}</li>
+        {%- endfor -%}
+      </{{ list_type }}>
+    {%- else -%}
+      {{- empty -}}
+    {%- endif -%}
+  {%- endif %}
+
+{% if facet.widget.type == "dropdown" %}
+  <label id="facet_{{ facet.id }}_label">{{ 'Facet'|t }} {{ facet.label }}</label>
+{%- endif %}
+</div>

--- a/templates/misc/facets-summary-item-list.html.twig
+++ b/templates/misc/facets-summary-item-list.html.twig
@@ -1,0 +1,57 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a facets summary item list.
+ *
+ * Available variables:
+ * - items: A list of items. Each item contains:
+ *   - attributes: HTML attributes to be applied to each list item.
+ *   - value: The content of the list element.
+ * - title: The title of the list.
+ * - list_type: The tag for list element ("ul" or "ol").
+ * - wrapper_attributes: HTML attributes to be applied to the list wrapper.
+ * - attributes: HTML attributes to be applied to the list.
+ * - empty: A message to display when there are no items. Allowed value is a
+ *   string or render array.
+ * - context: A list of contextual data associated with the list. May contain:
+ *   - list_style: The custom list style.
+ *
+ * @see facets_summary_preprocess_facets_summary_item_list()
+ *
+ * @ingroup themeable
+ */
+#}
+{% set title = '' %}
+
+{% if cache_hash %}
+  <!-- facets cacheable metadata
+    hash: {{ cache_hash }}
+  {% if cache_contexts %}
+    contexts: {{ cache_contexts }}
+  {%- endif %}
+  {% if cache_tags %}
+    tags: {{ cache_tags }}
+  {%- endif %}
+  {% if cache_max_age %}
+    max age: {{ cache_max_age }}
+  {%- endif %}
+  -->
+{%- endif %}
+{% if context.list_style %}
+  {%- set attributes = attributes.addClass('item-list__' ~ context.list_style) %}
+{% endif %}
+{% if items or empty %}
+  {%- if title is not empty -%}
+    <h3>{{ title }}</h3>
+  {%- endif -%}
+
+  {%- if items -%}
+    <{{ list_type }}{{ attributes }}>
+      {%- for item in items -%}
+        <li{{ item.attributes }}>{{ item.value }}</li>
+      {%- endfor -%}
+    </{{ list_type }}>
+  {%- else -%}
+    {{- empty -}}
+  {%- endif -%}
+{%- endif %}


### PR DESCRIPTION
Introduces:

* Block layout page change so that facet blocks now indicate which view they're associated with:

![image](https://user-images.githubusercontent.com/451261/220370923-0f2ce57e-55dc-41aa-9267-4ed460f0bcde.png)

* Review of Solr config files to confirm group related fields are no longer being added to Solr documents.
