### PR TITLE
Remove reference to block that isn't in use anymore

### DIFF
--- a/templates/content/node--contact--full.html.twig
+++ b/templates/content/node--contact--full.html.twig
@@ -81,7 +81,6 @@
   <div{{ content_attributes }}>
   {% endif %}
   {{- content -}}
-  {{ drupal_block('views_block:contact_children-contact_children', wrapper=false) }}
   {% if  content_attributes is not empty %}
   </div>
   {% endif %}


### PR DESCRIPTION
There isn't anything visible on production (D7) on a page such as https://www.daera-ni.gov.uk/contacts/daera-direct-regional-offices so removing this call to render an older views block as it doesn't seem to exist.