### PR TITLE
DEPT-386 Templates for normal search display (mirrors metadata search templates)

### DIFF
--- a/templates/content/node--consultation--search-metadata.html.twig
+++ b/templates/content/node--consultation--search-metadata.html.twig
@@ -78,17 +78,7 @@
 {% endif %}
 {{ title_suffix }}
 
-{% if display_submitted %}
-  <footer>
-    {{ author_picture }}
-    <div{{ author_attributes }}>
-      {% trans %}Submitted by {{ author_name }} on {{ date }}{% endtrans %}
-      {{ metadata }}
-    </div>
-  </footer>
-{% endif %}
-
-{#{{ content }}#}
+{{ content | without('field_published_date', 'consultation_status') }}
 <div class="card__meta">
   {{ content.field_published_date }}
   {{ content.consultation_status }}

--- a/templates/content/node--consultation--search-result.html.twig
+++ b/templates/content/node--consultation--search-result.html.twig
@@ -78,15 +78,9 @@
 {% endif %}
 {{ title_suffix }}
 
-{{ content | without('field_published_date', 'departments') }}
+{#{{ content }}#}
 <div class="card__meta">
   {{ content.field_published_date }}
-  {% if content.departments %}
-  <span class="department-name">
-    {% for department in content.departments %}
-      {{ department }}{% if not loop.last %} ,{% endif %}
-    {% endfor %}
-  </span>
-  {% endif %}
+  {{ content.consultation_status }}
 </div>
 

--- a/templates/content/node--publication--search-result.html.twig
+++ b/templates/content/node--publication--search-result.html.twig
@@ -1,0 +1,14 @@
+{#
+/**
+ * @file
+ * Theme override to display a publication node in search result view mode.
+#}
+<h3 class="card__title"><a href="{{ url }}">{{ label }}</a></h3>
+<p class="field-content card__content">{{ content.field_summary | field_value }}</p>
+<p class="card__meta">
+  <span class="label-inline">{{ "Published" | t}} </span>
+  <span class="date-display-single">{{ content.field_published_date | field_value }}</span>
+  <span class="card__meta-type">{{ content.field_publication_type | field_value }}</span>
+</p>
+
+{{ content | without('field_published_date', 'field_publication_type', 'field_summary') }}


### PR DESCRIPTION
A first step towards bringing search_result + search_metadata together. If the output looks okay (bit of scope creep here) then I'd suggest a process to reconcile the two as they're effectively replicating each other in templates and config. I didn't want to start pulling this apart right away until it's definite we're sticking with this approach.

NIGOV search view mode is a bit different again as it produces the department label on news CTs, but have intentionally left this out.

Some questions around news display config remain too as the template prints specific node field values an omits `{{ content }}`. This might cause some issue with cache tags/metadata not necessarily being produced (usually triggered by rendering `{{ content | without('field1', 'field2') etc }}` but will need to investigate those specific aspects later.