### PR TITLE
New twigs for related content view / block

### DIFF
--- a/templates/block/block--views-block--content-by-site-subtopic-block-related-content.html.twig
+++ b/templates/block/block--views-block--content-by-site-subtopic-block-related-content.html.twig
@@ -1,0 +1,50 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{{ attach_library('nicsdru_origins_theme/toggle-list') }}
+{%
+  set classes = [
+  'sub-menu',
+  'sub-menu--related',
+  'toggle-list',
+]
+%}
+{% set attributes = attributes.setAttribute('data-toggle-length', '12') %}
+{% set attributes = attributes.setAttribute('aria-labelledby', 'related-content') %}
+{% set attributes = attributes.removeAttribute('id') %}
+{% set attributes = attributes.removeClass('views-element-container') %}
+{% set attributes = attributes.addClass(classes) %}
+<div{{ attributes }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes.addClass('menu-title').setAttribute('id', 'related-content') }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/templates/views/views-view-fields--content-by-site-subtopic--block-related-content.html.twig
+++ b/templates/views/views-view-fields--content-by-site-subtopic--block-related-content.html.twig
@@ -1,0 +1,9 @@
+{#
+/**
+ * @file
+ * Theme override to display all the fields in a row.
+ *
+ * @see template_preprocess_views_view_fields()
+ */
+#}
+{% include '@stable/views/views-view-fields.html.twig' %}

--- a/templates/views/views-view-list--content-by-site-subtopic--block-related-content.html.twig
+++ b/templates/views/views-view-list--content-by-site-subtopic--block-related-content.html.twig
@@ -1,0 +1,25 @@
+{#
+/**
+ * @file
+ * Theme override for a view template to display a list of rows.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the container.
+ * - rows: A list of rows for this list.
+ *   - attributes: The row's HTML attributes.
+ *   - content: The row's contents.
+ * - title: The title of this group of rows. May be empty.
+ * - list: @todo.
+ *   - type: Starting tag will be either a ul or ol.
+ *   - attributes: HTML attributes for the list element.
+ *
+ * @see template_preprocess_views_view_list()
+ */
+#}
+<ul class="list--hyphen-bullet">
+  {% for row in rows %}
+    <li{{ row.attributes }}>
+      {{- row.content -}}
+    </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
View has changed for related content menu shown on articles - so need new twigs.  Will remove the old twigs later.