### PR TITLE
Topic and Subtopic teaser twigs

### DIFF
--- a/templates/content/node--subtopic--topics-teaser.html.twig
+++ b/templates/content/node--subtopic--topics-teaser.html.twig
@@ -75,7 +75,7 @@
     <a href="{{ url }}">{{ label }}</a>
   </h2>
   <div class="card__content">
-    {{- content|without('field_topic_content') -}}
+    {{- content.field_summary -}}
     {% if content.field_topic_content.0 %}
       {% set links = [content.field_topic_content.0] %}
     {% endif %}

--- a/templates/content/node--topic--teaser.html.twig
+++ b/templates/content/node--topic--teaser.html.twig
@@ -70,12 +70,10 @@
  *   in different view modes.
  */
 #}
-<a{{ attributes.addClass("card") }} href="{{ url }}">
-  {% if not page %}
-    <h2{{ title_attributes.addClass("card__title") }}>
-      {{ label }}
-    </h2>
-  {% endif %}
+<a class="card" href="{{ url }}">
+  <h2 class="card__title">
+    {{ label }}
+  </h2>
   <div class="card__content">
     {{ content.field_summary }}
   </div>


### PR DESCRIPTION
Renaming some topic and subtopic related twigs to clear up confusion (mine) around topic "teaser" twigs and subtopic "topics teaser" twig.  Also fixed topic teaser twig so that quickedit links are not output inside topic card links.